### PR TITLE
Increase default timeout for `browserstack` env.

### DIFF
--- a/src/config/main.ejs
+++ b/src/config/main.ejs
@@ -491,7 +491,7 @@ module.exports = {
       disable_error_log: true,
       webdriver: {
         timeout_options: {
-          timeout: 15000,
+          timeout: 60000,
           retry_attempts: 3
         },
         keep_alive: true,


### PR DESCRIPTION
The default timeout while initiating a session with BrowserStack is not long enough when testing on mobile devices or Turboscale leading to frequent connection reset errors. This PR increases the timeout to handle such cases.