### PR TITLE
Add `disable_output_boxes` option in default generated configuration.

### DIFF
--- a/src/config/main.ejs
+++ b/src/config/main.ejs
@@ -45,6 +45,9 @@ module.exports = {
     port: 5173
   },
   <% } %>
+  // Set this to true to disable bounding boxes on terminal output. Useful when running in some CI environments.
+  disable_output_boxes: false,
+
   webdriver: {},
 
   test_workers: {


### PR DESCRIPTION
Added option to disable bounding boxes in terminal output.